### PR TITLE
new structure WIP

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,16 @@ function MyButton () {
 }
 MyButton.prototype = Object.create(Nanocomponent.prototype)
 
-MyButton.prototype._render = function (color) {
-  this._color = color
+MyButton.prototype._render = function () {
   return html`
-    <button style="background-color: ${color}">
+    <button style="background-color: ${this.props.color}">
       Click Me
     </button>
   `
 }
 
-MyButton.prototype._update = function (newColor) {
-  return newColor !== this._color
+MyButton.prototype._update = function (props) {
+  return props.color !== this.props.color
 }
 ```
 
@@ -89,6 +88,8 @@ Internal properties are:
   elements that render both in the browser and in Node.
 - `this._loaded`: boolean if the element is currently loaded on the DOM.
 - `this._onload`: reference to the [on-load][on-load] library.
+- `this.props`: current state properties
+- `this.oldProps`: previous state properties
 
 ### `DOMNode|placeholder = Nanocomponent.prototype.render()`
 Create an instance of the component. Calls `prototype._render()` if
@@ -99,13 +100,13 @@ node. This is useful for diffing algorithms like
 [nanomorph](https://github.com/yoshuawuyts/nanomorph) which use this method to
 determine if a portion of the tree should be walked.
 
-### `Nanocomponent.prototype._render([arguments])`
+### `Nanocomponent.prototype._render()`
 __Must be implemented.__ Render an HTML node with arguments. For
 `prototype._load()` and `prototype._unload()` to work, make sure you return the
 same node on subsequent renders. The Node that's initially returned is saved as
 `this._element`.
 
-### `Nanocomponent.prototype._update([arguments])`
+### `Nanocomponent.prototype._update(props)`
 __Must be implemented.__ Return a boolean to determine if `prototype._render()`
 should be called.  Not called on the first render.
 

--- a/example/index.js
+++ b/example/index.js
@@ -30,7 +30,7 @@ function mainView (state, emit) {
         <button onclick=${toSeattle}>Seattle</button>
       </nav>
       <main>
-        ${leaflet.render(state.coords)}
+        ${leaflet.render({ coords: state.coords })}
       </main>
     </body>
   `

--- a/example/leaflet.js
+++ b/example/leaflet.js
@@ -2,7 +2,6 @@
 var Nanocomponent = require('../')
 var nanologger = require('nanologger')
 var leaflet = require('leaflet')
-var onIdle = require('on-idle')
 var html = require('bel')
 
 module.exports = Leaflet
@@ -12,67 +11,56 @@ function Leaflet () {
   Nanocomponent.call(this)
 
   this._log = nanologger('leaflet')
-  this._element = null
-  this._coords = null
-  this._map = null
-  this._zoom = 12
+  this.reset()
 }
 Leaflet.prototype = Object.create(Nanocomponent.prototype)
 
-Leaflet.prototype._render = function (coords) {
-  var self = this
-  this._coords = coords
-
-  if (!this._map) {
-    this._element = html`<div style="height: 500px"></div>`
-    if (this._hasWindow) this._createMap()
-  } else {
-    onIdle(function () {
-      self._updateMap()
-    })
+Leaflet.prototype._reset = function () {
+  this.state = {
+    map: null
   }
+  this.props = {
+    cords: null,
+    zoom: 12
+  }
+}
 
+Leaflet.prototype._render = function () {
+  if (!this._element) this._element = html`<div style="height: 500px"></div>`
+  if (!this.state.map && this._hasWindow) this._createMap()
+  else if (this.state.map) this._updateMap()
   return this._element
 }
 
-Leaflet.prototype._update = function (coords) {
-  return coords[0] !== this._coords[0] || coords[1] !== this._coords[1]
+Leaflet.prototype._update = function (props) {
+  return props.coords[0] !== this.props.coords[0] || props.coords[1] !== this.props.coords[1]
 }
 
 Leaflet.prototype._load = function () {
-  this._map.invalidateSize()
+  this.state.map.invalidateSize()
   this._log.info('load')
 }
 
 Leaflet.prototype._unload = function () {
   this._log.info('unload')
 
-  this._map.remove()
-  this._coords = null
-  this._map = null
-  this._element = null
+  this.state.map.remove()
+  this.reset()
 }
 
 Leaflet.prototype._createMap = function () {
-  var element = this._element
-  var coords = this._coords
-  var zoom = this._zoom
-
-  this._log.info('create-map', coords)
-
-  var map = leaflet.map(element).setView(coords, zoom)
+  this._log.info('create-map', this.props.coords)
+  this.state.map = leaflet.map(this._element).setView(this.props.coords, this.props.zoom)
   leaflet.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.{ext}', {
     attribution: 'Map tiles by <a href="https://stamen.com">Stamen Design</a>, <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
     subdomains: 'abcd',
     minZoom: 0,
     maxZoom: 20,
     ext: 'png'
-  }).addTo(map)
-  this._map = map
+  }).addTo(this.state.map)
 }
 
 Leaflet.prototype._updateMap = function () {
-  var coords = this._coords
-  this._log.info('update-map', coords)
-  this._map.setView(coords)
+  this._log.info('update-map', this.props.coords)
+  this.state.map.setView(this.props.coords)
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "bankai build example --optimize",
     "deps": "dependency-check . && dependency-check . --extra --no-dev -i yo-yoify",
-    "start": "bankai start example --optimize",
+    "start": "bankai start example",
     "test": "standard && npm run deps",
     "test:cov": "standard && npm run deps"
   },
@@ -31,7 +31,6 @@
     "leaflet": "^1.0.3",
     "microbounce": "^1.0.0",
     "nanologger": "^1.0.2",
-    "on-idle": "^1.0.0",
     "standard": "^8.6.0",
     "tachyons": "^4.6.1",
     "tape": "^4.6.3",


### PR DESCRIPTION
This is a WIP pull request, looking for early feedback.

This work started when I set out to implement a generic `._update` method that is set when you pass `{pure:true}` to the constructor. Ideally you shouldn't need to pass an array of properties to compare on.

When writing a generic `._update` however, this method needs to know from looking at the component's internal state, what kind of properties it should compare on. Iterating over `this` wouldn't work as you can't guarantee there isn't more attached than what you want to compare on. Eg that wouldn't work with this:

```js
function MyComponent () {
  Component.call(this)
  this.foo = 'bar' // a property to compare
  this.map = {} // internal state, not to compare
}
```

So instead, I added a mandatory `.props` field, similar to what react does:

```js
function MyComponent () {
  Component.call(this)
  this.props = {
    foo: 'bar' // a property to compare
  }
  this.map = {} // internal state, not to compare
}
```

While we're at it, I added `.state` as well - similar to react again - to help create good convention:

```js
function MyComponent () {
  Component.call(this)
  this.props = {
    foo: 'bar' // a property to compare
  }
  this.state = {
    map: {} // internal state, not to compare
  }
}
```

This is all you need to implement a proper default `._update()`! The actual method implementation has still to be done properly, that that could even happen in an external module.

With this structure in place, I realized we could also help remove a lot of boilerplate from the current `._render()` implementations as well. So I added automatic copying of assigned state!

Instead of this:

```js
MyComponent.prototype._render = function (props) {
  if (props.foo !== this.foo) { // do something special }
  this.foo = props.foo
  this.bar = props.bar
  this.baz = props.baz
  this._element = html`
    <div>${this.foo}: ${this.bar} (${this.baz})</div>
  `
  // ...
}
```

It's now simplified to this:

```js
MyComponent.prototype._render = function () {
  if (this.props.foo !== this.oldProps.foo) { // do something special }
  this._element = html`
    <div>${this.foo}: ${this.bar} (${this.baz})</div>
  `
  // ...
}
```

`.oldProps` lets to compare to previous state, if necessary.

There's one implications of this structural change to outwards interfaces, namely that you can't call `.render()` with more than one argument any more, and it always needs to be nothing or exactly one object as argument. I think that's fair though, multiple unnamed arguments tend to get messy anyway.

For the curious, the example is currently broken, I need to figure out what exactly I'm doing wrong / differently in respect to either nanocomponent or leaflet.

Very curious what you think! ✌️ 