### PR TITLE
More breaking changes by renaming lots of properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,21 +10,23 @@ Be sure to read the README so that you get an understanding of the new API, but 
 
 ### Changes since `cache-component@5`
 
-`nanocomponent@6` is mostly the same as `cache-component@5` except for the following:
+`nanocomponent@6` is mostly the same as `cache-component@5` except a few methods are rename and everything you interact with has had the `_` prefix removed.
 
 - **Breaking**: The `_element` [getter][getter] is renamed to `element`.
-- **Breaking**: `_willMount` is renamed to `_willRender` because DOM mounting can't be guaranteed from the perspective of a component.
-- **Breaking**: `_didMount` is removed.  Consider using `_load` instead now.  If you want this on-load free hook still, you can just call `window.requestAnimationFrame` from `_willRender`.
-- **Breaking**: `_willUpdate` is removed.  Anything you can do in `_willUpdate` you can just move to `_update`.
-- **Breaking**: `_update` should always be implemented.  Instead of the old default shallow compare, not implementing `_update` throws.  You can `require('nanocomponent/compare')` to implement the shallow compare if you want that still.  See below.
-- **Changed**: `_didUpdate()` now receives an element argument `el` e.g. `_didUpdate(el)`.  This makes it's argument signature consistent with the other life-cycle methods.
-- **Added**: Added [on-load][ol] hooks `_load` and `_unload`.  [on-load][ol] listeners only get added when one or both of the hooks are implemented on a component making the mutation observers optional.
+- **Breaking**: `_willMount` is renamed to `willRender` because DOM mounting can't be guaranteed from the perspective of a component.
+- **Breaking**: `_didMount` is removed.  Consider using `load` instead now.  If you want this on-load free hook still, you can just call `window.requestAnimationFrame` from `willRender`.
+- **Breaking**: `_willUpdate` is removed.  Anything you can do in `_willUpdate` you can just move to `update`.
+- **Breaking**: `_update` is rename to `update` and should always be implemented.  Instead of the old default shallow compare, not implementing `update` throws.  You can `require('nanocomponent/compare')` to implement the shallow compare if you want that still.  See below.
+- **Breaking**: `_args` is renamed to `lastArgs`.
+- **Breaking**: `_hasWindow` is renamed to `hasWindow`.
+- **Changed**: `_didUpdate()` is renamed to `didUpdate` now receives an element argument `el` e.g. `didUpdate(el)`.  This makes it's argument signature consistent with the other life-cycle methods.
+- **Added**: Added [on-load][ol] hooks `load` and `unload`.  [on-load][ol] listeners only get added when one or both of the hooks are implemented on a component making the mutation observers optional.
 
 
 #### `cache-component@5` to `nanocomponent@6` upgrade guide:
 
-- No changes nessisary to `_render`
-- You must implement `_update` now.  Here is an example of doing shallow compare on components that didn't implement their own update function previously:
+- Renamed `_render` to `createElement`.
+- You must implement `update` now.  Rename existing `_update` method to `update`.  Here is an example of doing shallow compare on components that didn't implement their own update function previously:
 
 ```js
 var html = require('choo/html')
@@ -40,7 +42,7 @@ class Meta extends Component {
     this._album = null
   }
 
-  _render (title, artist, album) {
+  createElement (title, artist, album) {
     this._title = title || '--'
     this._artist = artist || '--'
     this._album = album || '--'
@@ -56,19 +58,19 @@ class Meta extends Component {
   }
 
   // Implement this to recreate cache-component@5
-  // behavior when _update was not implemented
-  _update () {
-    return compare(arguments, this._args)
+  // behavior when update was not implemented
+  update () {
+    return compare(arguments, this.lastArgs)
   }
 }
 
 ```
 
-- Rename components with `_willMount` to `_willRender`
-- Move any `_didMount` implementations into `_load` or a `window.requestAnmimationFrame` inside of `_willRender`.
-- Move any `_willUpdate` implementations into `_update`.
-- `_didUpdate` remains the same.
-- Take advantage of `_load` and `_unload` for DOM insertion aware node interactions 🙌
+- Rename components with `_willMount` to `willRender`
+- Move any `_didMount` implementations into `load` or a `window.requestAnmimationFrame` inside of `willRender`.
+- Move any `_willUpdate` implementations into `update`.
+- Rename `_didUpdate` to `_didUpdate`.
+- Take advantage of `load` and `unload` for DOM insertion aware node interactions 🙌
 
 ### Changes since nanocomponent@5
 
@@ -76,20 +78,22 @@ class Meta extends Component {
 
 - **Breaking**: The `_element` property is removed.  A [getter][getter] called `element` is now used instead.  Since this is now a read-only getter, you must not assign anything to this property or else bad things will happen.  The `element` getter returns the component's DOM node if mounted in the page, and `undefined` otherwise.  You are allowed to mutate that DOM node by hand however.  Just don't reassign the property on the component instance.
 - **Changed**: `render` can now handle being removed and re-rendered into the DOM.  It can also handle rendering two instances of components in two different views over each other.
-- **Breaking**: `_render` must now return a DOM node always.  In earlier versions you could get away with not returning from `_render` and assigning nodes to `_element`.  No longer!  Also, you should move your DOM mutations into `_update`.
-- **Changed**: Update still works the same way: return true to run `_render` or return false to skip a call to `_render` when `render` is called.  If you decide to mutate `element` "by hand" on updates, do that here (rather than conditional paths inside `_render`).
-- **Changed**: `_load` and `_unload` have always been optional, but now the mutation observers are only added if at least one of these methods are implemented prior to component instantiation.
-- **Added**: `_willRender` lifecycle hook.  Its similar to `_load` but runs before mounting.
-- **Added**: `_didUpdate` runs after `_update` returns true and the results of `_render` is mutated over the mounted component.  Useful for adjusting scroll position.
+- **Breaking**: `_render` is renamed to `createElement` and must now return a DOM node always.  In earlier versions you could get away with not returning from `_render` and assigning nodes to `_element`.  No longer!  Also, you should move your DOM mutations into `update`.
+- **Changed**: Update still works the same way: return true to run `createElement` or return false to skip a call to `createElement` when `render` is called.  If you decide to mutate `element` "by hand" on updates, do that here (rather than conditional paths inside `createElement`).
+- **Changed**: `_load` and `_unload` renamed to `load` and `unload`. They have always been optional, but now the mutation observers are only added if at least one of these methods are implemented prior to component instantiation.
+- **Added**: `willRender` lifecycle hook.  Its similar to `load` but runs before mounting.
+- **Added**: `didUpdate` runs after `update` returns true and the results of `createElement` is mutated over the mounted component.  Useful for adjusting scroll position.
 - **Fixed**: More robust unmount and remounting behavior.
 
 #### `nanocomponent@5` to `nanocomponent@6` upgrade guide:
 
 - Read through the new leaflet example to get an idea of the differences between the old and new API. 🗺
-- Move any DOM mutation code from `_render` into `_update`.
-- Ensure `_render` returns a DOM node always. (You will get warnings if you don't and it probably won't work)
-- Consider moving any `_load` actions into `_willRender` if they don't depend on the newly rendered node being mounted in a DOM tree yet.
-- Take advantage of `_didUpdate` allowing you to interact with your component after `_render` is called on mounted components 🙌
+- Renamed `_render` to `createElement` and `_update` to `update`.
+- Move any DOM mutation code from `createElement` into `update`.
+- Ensure `createElement` returns a DOM node always. (You will get warnings if you don't and it probably won't work)
+- Rename `_load` and `_unload` to `load` and `unload`.
+- Consider moving any `load` actions into `willRender` if they don't depend on the newly rendered node being mounted in a DOM tree yet.
+- Take advantage of `didUpdate` allowing you to interact with your component after `createElement` is called on mounted components 🙌
 
 ## 5.2.0
 * Added more lifecycle hooks: `_willMount`, `_didMount`, `_willUpdate` in addition to `_didUpdate`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@ Be sure to read the README so that you get an understanding of the new API, but 
 
 - **Breaking**: The `_element` [getter][getter] is renamed to `element`.
 - **Breaking**: `_willMount` is renamed to `beforerender` because DOM mounting can't be guaranteed from the perspective of a component.
-- **Breaking**: `_didMount` is removed.  Consider using `load` instead now.  If you want this on-load free hook still, you can just call `window.requestAnimationFrame` from `willRender`.
-- **Breaking**: `_willUpdate` is removed.  Anything you can do in `_willUpdate` you can just move to `update`.
+- **Breaking**: `_didMount` is removed.  Consider using `load` instead now.  Anything you can do in `_willUpdate` you can just move to `update`.
 - **Breaking**: `_update` is renamed to `update` and should always be implemented.  Instead of the old default shallow compare, not implementing `update` throws.  You can `require('nanocomponent/compare')` to implement the shallow compare if you want that still.  See below.
 - **Breaking**: `_args` is removed.  `arguments` in `createElement` and `update` are already "sliced", so you can simply capture a copy in `update` and `createElement` and use it for comparison at a later time.
 - **Breaking**: `_hasWindow` is renamed to `hasWindow`.
@@ -88,7 +87,7 @@ class Meta extends Component {
 - Move any DOM mutation code from `createElement` into `update`.
 - Ensure `createElement` returns a DOM node always. (You will get warnings if you don't and it probably won't work)
 - Rename `_load` and `_unload` to `load` and `unload`.
-- Consider moving any `load` actions into `willRender` if they don't depend on the newly rendered node being mounted in a DOM tree yet.
+- Consider moving any `load` actions into `beforerender` if they don't depend on the newly rendered node being mounted in a DOM tree yet.
 - Take advantage of `didUpdate` allowing you to interact with your component after `createElement` is called on mounted components 🙌
 
 ## 5.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Be sure to read the README so that you get an understanding of the new API, but 
 - **Breaking**: `_didMount` is removed.  Consider using `load` instead now.
 - **Breaking**: `_update` is renamed to `update` and should always be implemented.  Instead of the old default shallow compare, not implementing `update` throws.  You can `require('nanocomponent/compare')` to implement the shallow compare if you want that still.  See below.
 - **Breaking**: `_args` is removed.  `arguments` in `createElement` and `update` are already "sliced", so you can simply capture a copy in `update` and `createElement` and use it for comparison at a later time.
-- **Breaking**: `_hasWindow` is renamed to `hasWindow`.
 - **Breaking**: `_willUpdate` is removed.  Anything you could do in `_willUpdate` you can just move to `update`.
 - **Changed**: `_didUpdate` is renamed to `afterupdate`.  It alsot receives an element argument `el` e.g. `afterupdate(el)`.  This makes its argument signature consistent with the other life-cycle methods.
 - **Added**: Added [on-load][ol] hooks `load` and `unload`.  [on-load][ol] listeners only get added when one or both of the hooks are implemented on a component making the mutation observers optional.
@@ -89,40 +88,10 @@ class Meta extends Component {
 - Ensure `createElement` returns a DOM node always. (You will get warnings if you don't and it probably won't work)
 - Rename `_load` and `_unload` to `load` and `unload`.
 - Consider moving any `load` actions into `beforerender` if they don't depend on the newly rendered node being mounted in a DOM tree yet.
-- Take advantage of `didUpdate` allowing you to interact with your component after `createElement` is called on mounted components 🙌
-
-## 5.2.0
-* Added more lifecycle hooks: `_willMount`, `_didMount`, `_willUpdate` in addition to `_didUpdate`.
-
-## 5.1.0
-* Update [nanomorph](http://ghub.io/nanomorph) to `^5.1.2`.  This adds the new child-reordering algorithm so we get a minor version bump.  Keep an eye out for weird ness and report broken corner cases 🙏
-
-## 5.0.1
-* Fix proxy leak by resetting proxy node ID after DOM removal is detected.
-
-## 5.0.0
-* Update [bel](http://ghub.io/bel) to ^5.0.0
-
-## 5.0.0-1 - 2017-05-16
-* Beta release!  Please let me know if there is anything wrong with this!
-* **Breaking**: Remove `on-load` and use a new DOM ID based DOM tracking system.  Requires ES5 support for getters.
-* **Breaking**: Remove `_load` and `_unload` methods.  You have to wrap instances of `cache-component` with `on-load` on your own now.
-* **Added**: Add `_didUpdate` hook so you can call DOM methods after the component updates.  Handy for updating a scroll position.
-
-## 4.0.2 - 2017-05-05
-* Run _unload before we clear internal references, allowing you to clean up event listeners on `this._element` and anything else you want to do.
-
-## 4.0.1 - 2017-04-10
-* Fix instance clobbering bug.  This bug showed up when you had two instances of the same component morphing over each other.  This would cause the real DOM reference to get lost between the internal _element references of the two instances.  The work around was the introduction of ccId which is a unique ID to prevent this.
-
-## 4.0.0 - 2017-04-10
-* use [on-load](https://github.com/shama/on-load) to invalidate `this._element`.  Fixes component rendering when they get completely removed from the DOM.
-* added `_load` and `_unload` methods to allow you to run code when the DOM is mounted and unmounted.
-* handle morphing internally, and ALWAYSE return a proxy node.  There is no other way.
-
-## 3.0.0 - 2017-04-10
-* initial release
+- Take advantage of `afterupdate` allowing you to interact with your component after `createElement` is called on mounted components 🙌
 
 [ol]: https://github.com/shama/on-load
 [cc]: https://github.com/hypermodules/cache-component
+[bel]: http://ghub.io/bel
+[nm]: http://ghub.io/nanomorph
 [getter]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@ Be sure to read the README so that you get an understanding of the new API, but 
 
 - **Breaking**: The `_element` [getter][getter] is renamed to `element`.
 - **Breaking**: `_willMount` is renamed to `beforerender` because DOM mounting can't be guaranteed from the perspective of a component.
-- **Breaking**: `_didMount` is removed.  Consider using `load` instead now.  Anything you could do in `_willUpdate` you can just move to `update`.
+- **Breaking**: `_didMount` is removed.  Consider using `load` instead now.
 - **Breaking**: `_update` is renamed to `update` and should always be implemented.  Instead of the old default shallow compare, not implementing `update` throws.  You can `require('nanocomponent/compare')` to implement the shallow compare if you want that still.  See below.
 - **Breaking**: `_args` is removed.  `arguments` in `createElement` and `update` are already "sliced", so you can simply capture a copy in `update` and `createElement` and use it for comparison at a later time.
 - **Breaking**: `_hasWindow` is renamed to `hasWindow`.
-- **Changed**: `_didUpdate()` is renamed to `afterupdate`.  It alsot receives an element argument `el` e.g. `afterupdate(el)`.  This makes its argument signature consistent with the other life-cycle methods.
+- **Breaking**: `_willUpdate` is removed.  Anything you could do in `_willUpdate` you can just move to `update`.
+- **Changed**: `_didUpdate` is renamed to `afterupdate`.  It alsot receives an element argument `el` e.g. `afterupdate(el)`.  This makes its argument signature consistent with the other life-cycle methods.
 - **Added**: Added [on-load][ol] hooks `load` and `unload`.  [on-load][ol] listeners only get added when one or both of the hooks are implemented on a component making the mutation observers optional.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,16 @@ Be sure to read the README so that you get an understanding of the new API, but 
 
 ### Changes since `cache-component@5`
 
-`nanocomponent@6` is mostly the same as `cache-component@5` except a few methods are rename and everything you interact with has had the `_` prefix removed.
+`nanocomponent@6` is mostly the same as `cache-component@5` except a few methods are renamed and everything you interact with has had the `_` prefix removed.
 
 - **Breaking**: The `_element` [getter][getter] is renamed to `element`.
 - **Breaking**: `_willMount` is renamed to `willRender` because DOM mounting can't be guaranteed from the perspective of a component.
 - **Breaking**: `_didMount` is removed.  Consider using `load` instead now.  If you want this on-load free hook still, you can just call `window.requestAnimationFrame` from `willRender`.
 - **Breaking**: `_willUpdate` is removed.  Anything you can do in `_willUpdate` you can just move to `update`.
-- **Breaking**: `_update` is rename to `update` and should always be implemented.  Instead of the old default shallow compare, not implementing `update` throws.  You can `require('nanocomponent/compare')` to implement the shallow compare if you want that still.  See below.
-- **Breaking**: `_args` is renamed to `lastArgs`.
+- **Breaking**: `_update` is renamed to `update` and should always be implemented.  Instead of the old default shallow compare, not implementing `update` throws.  You can `require('nanocomponent/compare')` to implement the shallow compare if you want that still.  See below.
+- **Breaking**: `_args` is removed.  `arguments` in `createElement` and `update` are already "sliced", so you can simply capture a copy in `update` and `createElement` and use it for comparison at a later time.
 - **Breaking**: `_hasWindow` is renamed to `hasWindow`.
-- **Changed**: `_didUpdate()` is renamed to `didUpdate` now receives an element argument `el` e.g. `didUpdate(el)`.  This makes it's argument signature consistent with the other life-cycle methods.
+- **Changed**: `_didUpdate()` is renamed to `didUpdate`.  It alsot receives an element argument `el` e.g. `didUpdate(el)`.  This makes its argument signature consistent with the other life-cycle methods.
 - **Added**: Added [on-load][ol] hooks `load` and `unload`.  [on-load][ol] listeners only get added when one or both of the hooks are implemented on a component making the mutation observers optional.
 
 
@@ -37,15 +37,11 @@ class Meta extends Component {
   constructor () {
     super()
 
-    this._title = null
-    this._artist = null
-    this._album = null
+    this.arguments = []
   }
 
   createElement (title, artist, album) {
-    this._title = title || '--'
-    this._artist = artist || '--'
-    this._album = album || '--'
+    this.arguments = arguments // cache a copy of arguments
 
     return html`
       <div>
@@ -60,7 +56,7 @@ class Meta extends Component {
   // Implement this to recreate cache-component@5
   // behavior when update was not implemented
   update () {
-    return compare(arguments, this.lastArgs)
+    return compare(arguments, this.arguments)
   }
 }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,13 @@ Be sure to read the README so that you get an understanding of the new API, but 
 `nanocomponent@6` is mostly the same as `cache-component@5` except a few methods are renamed and everything you interact with has had the `_` prefix removed.
 
 - **Breaking**: The `_element` [getter][getter] is renamed to `element`.
-- **Breaking**: `_willMount` is renamed to `willRender` because DOM mounting can't be guaranteed from the perspective of a component.
+- **Breaking**: `_willMount` is renamed to `beforerender` because DOM mounting can't be guaranteed from the perspective of a component.
 - **Breaking**: `_didMount` is removed.  Consider using `load` instead now.  If you want this on-load free hook still, you can just call `window.requestAnimationFrame` from `willRender`.
 - **Breaking**: `_willUpdate` is removed.  Anything you can do in `_willUpdate` you can just move to `update`.
 - **Breaking**: `_update` is renamed to `update` and should always be implemented.  Instead of the old default shallow compare, not implementing `update` throws.  You can `require('nanocomponent/compare')` to implement the shallow compare if you want that still.  See below.
 - **Breaking**: `_args` is removed.  `arguments` in `createElement` and `update` are already "sliced", so you can simply capture a copy in `update` and `createElement` and use it for comparison at a later time.
 - **Breaking**: `_hasWindow` is renamed to `hasWindow`.
-- **Changed**: `_didUpdate()` is renamed to `didUpdate`.  It alsot receives an element argument `el` e.g. `didUpdate(el)`.  This makes its argument signature consistent with the other life-cycle methods.
+- **Changed**: `_didUpdate()` is renamed to `afterupdate`.  It alsot receives an element argument `el` e.g. `afterupdate(el)`.  This makes its argument signature consistent with the other life-cycle methods.
 - **Added**: Added [on-load][ol] hooks `load` and `unload`.  [on-load][ol] listeners only get added when one or both of the hooks are implemented on a component making the mutation observers optional.
 
 
@@ -62,10 +62,10 @@ class Meta extends Component {
 
 ```
 
-- Rename components with `_willMount` to `willRender`
-- Move any `_didMount` implementations into `load` or a `window.requestAnmimationFrame` inside of `willRender`.
+- Rename components with `_willMount` to `beforerender`
+- Move any `_didMount` implementations into `load` or a `window.requestAnmimationFrame` inside of `beforerender`.
 - Move any `_willUpdate` implementations into `update`.
-- Rename `_didUpdate` to `_didUpdate`.
+- Rename `_didUpdate` to `afterupdate`.
 - Take advantage of `load` and `unload` for DOM insertion aware node interactions 🙌
 
 ### Changes since nanocomponent@5
@@ -77,8 +77,8 @@ class Meta extends Component {
 - **Breaking**: `_render` is renamed to `createElement` and must now return a DOM node always.  In earlier versions you could get away with not returning from `_render` and assigning nodes to `_element`.  No longer!  Also, you should move your DOM mutations into `update`.
 - **Changed**: Update still works the same way: return true to run `createElement` or return false to skip a call to `createElement` when `render` is called.  If you decide to mutate `element` "by hand" on updates, do that here (rather than conditional paths inside `createElement`).
 - **Changed**: `_load` and `_unload` renamed to `load` and `unload`. They have always been optional, but now the mutation observers are only added if at least one of these methods are implemented prior to component instantiation.
-- **Added**: `willRender` lifecycle hook.  Its similar to `load` but runs before mounting.
-- **Added**: `didUpdate` runs after `update` returns true and the results of `createElement` is mutated over the mounted component.  Useful for adjusting scroll position.
+- **Added**: `beforerender` lifecycle hook.  Its similar to `load` but runs before mounting.
+- **Added**: `afterupdate` runs after `update` returns true and the results of `createElement` is mutated over the mounted component.  Useful for adjusting scroll position.
 - **Fixed**: More robust unmount and remounting behavior.
 
 #### `nanocomponent@5` to `nanocomponent@6` upgrade guide:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Be sure to read the README so that you get an understanding of the new API, but 
 - **Breaking**: `_update` is renamed to `update` and should always be implemented.  Instead of the old default shallow compare, not implementing `update` throws.  You can `require('nanocomponent/compare')` to implement the shallow compare if you want that still.  See below.
 - **Breaking**: `_args` is removed.  `arguments` in `createElement` and `update` are already "sliced", so you can simply capture a copy in `update` and `createElement` and use it for comparison at a later time.
 - **Breaking**: `_willUpdate` is removed.  Anything you could do in `_willUpdate` you can just move to `update`.
-- **Changed**: `_didUpdate` is renamed to `afterupdate`.  It alsot receives an element argument `el` e.g. `afterupdate(el)`.  This makes its argument signature consistent with the other life-cycle methods.
+- **Changed**: `_didUpdate` is renamed to `afterupdate`.  It also receives an element argument `el` e.g. `afterupdate(el)`.  This makes its argument signature consistent with the other life-cycle methods.
 - **Added**: Added [on-load][ol] hooks `load` and `unload`.  [on-load][ol] listeners only get added when one or both of the hooks are implemented on a component making the mutation observers optional.
 
 
@@ -67,18 +67,17 @@ class Meta extends Component {
 - Rename `_didUpdate` to `afterupdate`.
 - Take advantage of `load` and `unload` for DOM insertion aware node interactions 🙌
 
-### Changes since nanocomponent@5
+### Changes since `nanocomponent@5`
 
 `nanocomponent@6` has some subtle but important differences from `nanocompnent@5`.  Be sure to read the README and check out the examples to get an understanding of the new API.
 
 - **Breaking**: The `_element` property is removed.  A [getter][getter] called `element` is now used instead.  Since this is now a read-only getter, you must not assign anything to this property or else bad things will happen.  The `element` getter returns the component's DOM node if mounted in the page, and `undefined` otherwise.  You are allowed to mutate that DOM node by hand however.  Just don't reassign the property on the component instance.
-- **Changed**: `render` can now handle being removed and re-rendered into the DOM.  It can also handle rendering two instances of components in two different views over each other.
+- **Fixed**: Components can gracefully be removed, re-ordered and remounted between views.  You can even mutate the same component over individual instances.  This is an improvement over `nanocomponent@5`.
 - **Breaking**: `_render` is renamed to `createElement` and must now return a DOM node always.  In earlier versions you could get away with not returning from `_render` and assigning nodes to `_element`.  No longer!  Also, you should move your DOM mutations into `update`.
 - **Changed**: Update still works the same way: return true to run `createElement` or return false to skip a call to `createElement` when `render` is called.  If you decide to mutate `element` "by hand" on updates, do that here (rather than conditional paths inside `createElement`).
 - **Changed**: `_load` and `_unload` renamed to `load` and `unload`. They have always been optional, but now the mutation observers are only added if at least one of these methods are implemented prior to component instantiation.
-- **Added**: `beforerender` lifecycle hook.  Its similar to `load` but runs before mounting.
+- **Added**: `beforerender` lifecycle hook.  Its similar to `load` but runs before the function call to `render` returns on unmounted component instances.  This is where the [on-load][ol] listeners are added and is a good opportunity to add any other lifecycle hooks.
 - **Added**: `afterupdate` runs after `update` returns true and the results of `createElement` is mutated over the mounted component.  Useful for adjusting scroll position.
-- **Fixed**: More robust unmount and remounting behavior.
 
 #### `nanocomponent@5` to `nanocomponent@6` upgrade guide:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Be sure to read the README so that you get an understanding of the new API, but 
 
 - **Breaking**: The `_element` [getter][getter] is renamed to `element`.
 - **Breaking**: `_willMount` is renamed to `beforerender` because DOM mounting can't be guaranteed from the perspective of a component.
-- **Breaking**: `_didMount` is removed.  Consider using `load` instead now.  Anything you can do in `_willUpdate` you can just move to `update`.
+- **Breaking**: `_didMount` is removed.  Consider using `load` instead now.  Anything you could do in `_willUpdate` you can just move to `update`.
 - **Breaking**: `_update` is renamed to `update` and should always be implemented.  Instead of the old default shallow compare, not implementing `update` throws.  You can `require('nanocomponent/compare')` to implement the shallow compare if you want that still.  See below.
 - **Breaking**: `_args` is removed.  `arguments` in `createElement` and `update` are already "sliced", so you can simply capture a copy in `update` and `createElement` and use it for comparison at a later time.
 - **Breaking**: `_hasWindow` is renamed to `hasWindow`.

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ property that returns the component's DOM node if its mounted in the page and
 __Must be implemented.__ Component specific render function.  Optionally cache
 argument values here.  Run anything here that needs to run along side node
 rendering.  Must return a DOMNode. Use `beforerender` to run code after
-`createElement` when the component is unmounted.  Previously named `_render`.  Arguments that passed to `render` are passed to `createElement`.
+`createElement` when the component is unmounted.  Previously named `_render`.  Arguments that passed to `render` are passed to `createElement`.  Elements returned from `createElement` must always return the same root node type.
 
 ### `Boolean = Nanocomponent.prototype.update([arguments…])`
 __Must be implemented.__ Return a boolean to determine if

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ its conception.
 Create a new Nanocomponent instance. Additional methods can be set on the
 prototype.
 
-### `component.render([…arguments])`
+### `component.render([arguments…])`
 Render the component. Returns a proxy node if already mounted on the DOM. Proxy
 nodes make it so DOM diffing algorithms leave the element alone when diffing.
 
@@ -288,21 +288,17 @@ A [getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Fun
 property that returns the component's DOM node if its mounted in the page and
 `null` when its not.
 
-### `component.hasWindow`
-Boolean that reflects if the component is rendered in a browser environment.  Can be useful for
-components that are server side rendering friendly.
-
 ### `DOMNode = Nanocomponent.prototype.createElement([arguments…])`
 __Must be implemented.__ Component specific render function.  Optionally cache
 argument values here.  Run anything here that needs to run along side node
 rendering.  Must return a DOMNode. Use `beforerender` to run code after
-`createElement` when the component is unmounted.  Previously named `_render`.
+`createElement` when the component is unmounted.  Previously named `_render`.  Arguments that passed to `render` are passed to `createElement`.
 
 ### `Boolean = Nanocomponent.prototype.update([arguments…])`
 __Must be implemented.__ Return a boolean to determine if
 `prototype.createElement()` should be called.  The `update` method is analogous to
 React's `shouldComponentUpdate`. Called only when the component is mounted in
-the DOM tree.
+the DOM tree.  Arguments passed to `render` are passed to `update`.
 
 ### `Nanocomponent.prototype.beforerender(el)`
 A function called right after `createElement` returns with `el`, but before the fully rendered

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Component.prototype.update = function (state) {
   return false // always return false when mounted
 }
 
+// Some arbitrary data shaping function
 function shapeData (state) {
   return [state.colors.color1, state.colors.color2, state.colors.color3]
 }

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ components that are server side rendering friendly.
 ### `DOMNode = Nanocomponent.prototype.createElement([arguments…])`
 __Must be implemented.__ Component specific render function.  Optionally cache
 argument values here.  Run anything here that needs to run along side node
-rendering.  Must return a DOMNode. Use `willRender` to run code after
+rendering.  Must return a DOMNode. Use `beforerender` to run code after
 `createElement` when the component is unmounted.  Previously named `_render`.
 
 ### `Boolean = Nanocomponent.prototype.update([arguments…])`
@@ -303,7 +303,7 @@ __Must be implemented.__ Return a boolean to determine if
 React's `shouldComponentUpdate`. Called only when the component is mounted in
 the DOM tree.
 
-### `Nanocomponent.prototype.willRender(el)`
+### `Nanocomponent.prototype.beforerender(el)`
 A function called right after `createElement` returns with `el`, but before the fully rendered
 element is returned to the `render` caller. Run any first render hooks here. The `load` and
 `unload` hooks are added at this stage.
@@ -316,7 +316,7 @@ the hood.
 Called when the component is removed from the DOM. Uses [on-load][onload] under
 the hood.
 
-### `Nanocomponent.prototype.didUpdate(el)`
+### `Nanocomponent.prototype.afterupdate(el)`
 Called after a mounted component updates (e.g. `update` returns true).  You can use this hook to call
 `element.scrollIntoView` or other dom methods on the mounted component.
 

--- a/README.md
+++ b/README.md
@@ -287,10 +287,6 @@ A [getter](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Fun
 property that returns the component's DOM node if its mounted in the page and
 `null` when its not.
 
-### `component.lastArgs`
-A property that has a copy of all arguments used during the last call to `createElement`.
-Useful for implementing argument comparisons in `update` during calls to `render`.
-
 ### `component.hasWindow`
 Boolean that reflects if the component is rendered in a browser environment.  Can be useful for
 components that are server side rendering friendly.

--- a/example/leaflet.js
+++ b/example/leaflet.js
@@ -40,7 +40,7 @@ Leaflet.prototype.update = function (coords) {
   return false
 }
 
-Leaflet.prototype.willRender = function (el) {
+Leaflet.prototype.beforerender = function (el) {
   var coords = this.coords
   this._log.info('create-map', coords)
 

--- a/example/leaflet.js
+++ b/example/leaflet.js
@@ -18,7 +18,7 @@ function Leaflet () {
 
 Leaflet.prototype = Object.create(Nanocomponent.prototype)
 
-Leaflet.prototype._render = function (coords) {
+Leaflet.prototype.createElement = function (coords) {
   this.coords = coords
   return html`
     <div style="height: 500px">
@@ -27,7 +27,7 @@ Leaflet.prototype._render = function (coords) {
   `
 }
 
-Leaflet.prototype._update = function (coords) {
+Leaflet.prototype.update = function (coords) {
   if (!this.map) return this._log.warn('missing map', 'failed to update')
   if (coords[0] !== this.coords[0] || coords[1] !== this.coords[1]) {
     var self = this
@@ -40,7 +40,7 @@ Leaflet.prototype._update = function (coords) {
   return false
 }
 
-Leaflet.prototype._willRender = function (el) {
+Leaflet.prototype.willRender = function (el) {
   var coords = this.coords
   this._log.info('create-map', coords)
 
@@ -55,12 +55,12 @@ Leaflet.prototype._willRender = function (el) {
   this.map = map
 }
 
-Leaflet.prototype._load = function () {
+Leaflet.prototype.load = function () {
   this._log.info('load')
   this.map.invalidateSize()
 }
 
-Leaflet.prototype._unload = function () {
+Leaflet.prototype.unload = function () {
   this._log.info('unload')
 
   this.map.remove()

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function makeID () {
 }
 
 function Nanocomponent () {
-  this.hasWindow = typeof window !== 'undefined'
+  this._hasWindow = typeof window !== 'undefined'
   this._id = null // represents the id of the root node
   this._ncID = null // internal nanocomponent id
   this._proxy = null
@@ -33,7 +33,7 @@ Nanocomponent.prototype.render = function () {
   var self = this
   var args = new Array(arguments.length)
   for (var i = 0; i < arguments.length; i++) args[i] = arguments[i]
-  if (!this.hasWindow) {
+  if (!this._hasWindow) {
     return this.createElement.apply(this, args)
   } else if (this.element) {
     var shouldUpdate = this.update.apply(this, args)

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function Nanocomponent () {
   this._ncID = null // internal nanocomponent id
   this._proxy = null
   this._loaded = false // Used to debounce on-load when child-reordering
+  this._rootNodeName = null
 
   this._handleLoad = this._handleLoad.bind(this)
   this._handleUnload = this._handleUnload.bind(this)
@@ -57,7 +58,9 @@ Nanocomponent.prototype.render = function () {
 
 Nanocomponent.prototype._handleRender = function (args) {
   var el = this.createElement.apply(this, args)
+  if (!this._rootNodeName) this._rootNodeName = el.nodeName
   assert(el instanceof window.HTMLElement, 'nanocomponent: createElement should return a DOM node')
+  assert.equal(this._rootNodeName, el.nodeName, 'nanocomponent: root node types cannot differ between re-renders')
   return this._brandNode(this._ensureID(el))
 }
 

--- a/index.js
+++ b/index.js
@@ -39,7 +39,7 @@ Nanocomponent.prototype.render = function () {
     var shouldUpdate = this.update.apply(this, args)
     if (shouldUpdate) {
       morph(this.element, this._handleRender(args))
-      if (this.didUpdate) window.requestAnimationFrame(function () { self.didUpdate(self.element) })
+      if (this.afterupdate) window.requestAnimationFrame(function () { self.afterupdate(self.element) })
     }
     if (!this._proxy) { this._proxy = this._createProxy() }
     return this._proxy
@@ -47,7 +47,7 @@ Nanocomponent.prototype.render = function () {
     this._ncID = makeID()
     this._proxy = null
     var el = this._handleRender(args)
-    if (this.willRender) this.willRender(el)
+    if (this.beforerender) this.beforerender(el)
     if (this.load || this.unload) {
       onload(el, this._handleLoad, this._handleUnload, this)
     }

--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ function makeID () {
 
 function Nanocomponent () {
   this.hasWindow = typeof window !== 'undefined'
-  this.lastArgs = [] // Copy of arguments from last render
   this._id = null // represents the id of the root node
   this._ncID = null // internal nanocomponent id
   this._proxy = null
@@ -39,7 +38,6 @@ Nanocomponent.prototype.render = function () {
   } else if (this.element) {
     var shouldUpdate = this.update.apply(this, args)
     if (shouldUpdate) {
-      this.lastArgs = args
       morph(this.element, this._handleRender(args))
       if (this.didUpdate) window.requestAnimationFrame(function () { self.didUpdate(self.element) })
     }
@@ -47,7 +45,6 @@ Nanocomponent.prototype.render = function () {
     return this._proxy
   } else {
     this._ncID = makeID()
-    this.lastArgs = args
     this._proxy = null
     var el = this._handleRender(args)
     if (this.willRender) this.willRender(el)

--- a/test/node.js
+++ b/test/node.js
@@ -6,7 +6,7 @@ test('cache', (t) => {
   t.test('should validate input types', (t) => {
     t.plan(1)
     var comp = new Nanocomponent()
-    t.throws(comp.render.bind(comp), /_render should be implemented/)
+    t.throws(comp.render.bind(comp), /createElement should be implemented/)
   })
 
   t.test('should render elements', (t) => {
@@ -18,8 +18,12 @@ test('cache', (t) => {
     }
     MyComp.prototype = Object.create(Nanocomponent.prototype)
 
-    MyComp.prototype._render = function (name) {
+    MyComp.prototype.createElement = function (name) {
       return html`<div>${name}</div>`
+    }
+
+    MyComp.prototype.update = function (name) {
+      return false
     }
 
     var myComp = new MyComp()


### PR DESCRIPTION
- Remove _ from all methods users tend to interact with
- Rename `_render` to `createElement`
- Rename `_update` to `update`
- Rename `_load` and `_unload` to `load` and `unload`
- rename `_willRender` and `_didUpdate` to `beforerender` and `afterupdate`
- Removed `_args` and updated shallow compare example
- Updated examples, docs and changelog to reflect all of this.
- Added assertion that root Dom node types do not change between renders.

UPDATE: Incorporated feedback