### PR TITLE
Fix typo in check for afterreorder

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ Nanocomponent.prototype.render = function () {
     this._reset()
     el = this._handleRender(args)
     if (this.beforerender) this.beforerender(el)
-    if (this.load || this.unload || this.afterrreorder) {
+    if (this.load || this.unload || this.afterreorder) {
       onload(el, self._handleLoad, self._handleUnload, self)
     }
     timing()


### PR DESCRIPTION
I stumbled over this typo while writing tests for a wrapper implementation of Nanocomponent. I also noticed that Nanocomponent has no tests for reordering. I would have added them, had I been able to figure out how it's supposed to work.