### PR TITLE
Run afterreorder immediately

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ Nanocomponent.prototype._ensureID = function (node) {
 Nanocomponent.prototype._handleLoad = function (el) {
   var self = this
   if (this._loaded) {
-    if (this.afterreorder) window.requestAnimationFrame(function () { self.afterreorder(el) })
+    if (this.afterreorder) self.afterreorder(el)
     return // Debounce child-reorders
   }
   this._loaded = true


### PR DESCRIPTION
Offsetting `afterreorder` to next animation frame makes it difficult to do any kind of animation in reaction to reordering, seeing as the new order will already have been repainted by the browser before the callback is fired.

Chrome and Firefox handles it quite nicely offsetting the repaint two frames so that the animation runs smoothly but *Safari* seems to perform an intermediate paint between the `requestAnimationFrame` in nanocomponent and the `requestAnimationFrame` in my script which is needed to make the animation happen, (see source: https://github.com/tornqvist/fun-component/blob/master/examples/list/index.js#L32)

Here's an example illustrating the issue: https://fun-component-list.now.sh

Am I missing an apparent reason for offsetting the callback? There are some other issues, e.g. not all elements are considered being reordered but just switch places, this is also visible in the example. But I think removing the `requestAnimationFrame` fixes the most pressing issue.