### PR TITLE
remove RAF wrappers around unload/load

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,14 +119,14 @@ Nanocomponent.prototype._handleLoad = function (el) {
     return // Debounce child-reorders
   }
   this._loaded = true
-  if (this.load) window.requestAnimationFrame(function () { self.load(el) })
+  if (this.load) self.load(el)
 }
 
 Nanocomponent.prototype._handleUnload = function (el) {
   var self = this
   if (this.element) return // Debounce child-reorders
   this._loaded = false
-  if (this.unload) window.requestAnimationFrame(function () { self.unload(el) })
+  if (this.unload) self.unload(el)
 }
 
 Nanocomponent.prototype.createElement = function () {

--- a/index.js
+++ b/index.js
@@ -46,11 +46,12 @@ Nanocomponent.prototype.render = function () {
     timing()
     return el
   } else if (this.element) {
+    el = this.element  // retain reference, as the ID might change on render
     var shouldUpdate = this._rerender || this.update.apply(this, args)
     if (this._rerender) this._render = false
     if (shouldUpdate) {
-      morph(this.element, this._handleRender(args))
-      if (this.afterupdate) this.afterupdate(this.element)
+      morph(el, this._handleRender(args))
+      if (this.afterupdate) this.afterupdate(el)
     }
     if (!this._proxy) { this._proxy = this._createProxy() }
     timing()
@@ -60,7 +61,7 @@ Nanocomponent.prototype.render = function () {
     el = this._handleRender(args)
     if (this.beforerender) this.beforerender(el)
     if (this.load || this.unload || this.afterreorder) {
-      onload(el, self._handleLoad, self._handleUnload, self)
+      onload(el, self._handleLoad, self._handleUnload, self._ncID)
     }
     timing()
     return el
@@ -109,24 +110,24 @@ Nanocomponent.prototype._brandNode = function (node) {
 Nanocomponent.prototype._ensureID = function (node) {
   if (node.id) this._id = node.id
   else node.id = this._id = this._ncID
+  // Update proxy node ID if it changed
+  if (this._proxy && this._proxy.id !== this._id) this._proxy.id = this._id
   return node
 }
 
 Nanocomponent.prototype._handleLoad = function (el) {
-  var self = this
   if (this._loaded) {
-    if (this.afterreorder) self.afterreorder(el)
+    if (this.afterreorder) this.afterreorder(el)
     return // Debounce child-reorders
   }
   this._loaded = true
-  if (this.load) self.load(el)
+  if (this.load) this.load(el)
 }
 
 Nanocomponent.prototype._handleUnload = function (el) {
-  var self = this
   if (this.element) return // Debounce child-reorders
   this._loaded = false
-  if (this.unload) self.unload(el)
+  if (this.unload) this.unload(el)
 }
 
 Nanocomponent.prototype.createElement = function () {

--- a/index.js
+++ b/index.js
@@ -50,7 +50,11 @@ Nanocomponent.prototype.render = function () {
     var shouldUpdate = this._rerender || this.update.apply(this, args)
     if (this._rerender) this._render = false
     if (shouldUpdate) {
-      morph(el, this._handleRender(args))
+      var newTree = this._handleRender(args)
+      Object.entries(el.dataset).forEach(entry => {
+        newTree.dataset[entry[0]] = entry[1]
+      })
+      morph(el, newTree)
       if (this.afterupdate) this.afterupdate(el)
     }
     if (!this._proxy) { this._proxy = this._createProxy() }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "nanoassert": "^1.1.0",
     "nanomorph": "^5.1.2",
     "nanotiming": "^6.1.3",
-    "on-load": "^3.2.3"
+    "on-load": "^3.3.1"
   },
   "devDependencies": {
     "@tap-format/spec": "^0.2.0",

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -128,8 +128,8 @@ test('lifecycle tests', function (t) {
   }
 
   var comp = new LifeCycleComp()
-  comp.bus.on('load', onLoad)
-  comp.bus.on('unload', onUnload)
+  comp.bus.on('load', () => window.requestAnimationFrame(onLoad))
+  comp.bus.on('unload', () => window.requestAnimationFrame(onUnload))
 
   t.deepEqual(comp.testState, {
     'create-element': 0,


### PR DESCRIPTION
This is based off of #58, but removes all of the RAF wrappers.

For further context, here is an IRC snippet from earlier today:

```
<toddself> bret: yeah i mean RAF isn't "ordered" like setTimeout is
6:59 PM <bret> if you spam the hell out of RAF, does it automatically run then at 60fps as long as a particular RAF doesn't go beyond the 12ms or whatever?
6:59 PM <toddself> i.e. if you you cotinously call setTimeout, all those timeouts will expire in the order in which you call them (if they're all set to the same time)
6:59 PM <bret> lrlna: I can try to get something out tonight, but if you want you can try removing those RAFs and npm link
6:59 PM <toddself> RAF is going to batch all the calls but i don't think it's going to do anything with regards to timing
7:00 PM <bret> toddself: ah wow ok
7:00 PM toddself: there is some weirdness with removing them, I think. on-load error or something with out them but I didn't look into why and just kept them
7:01 PM <toddself> bret: i'm not 100% positive on this but itseems like it isn't doing it in order of RAF calls
7:01 PM bret: or there's stuff with mutation observers
7:01 PM bret: and how they interact
7:02 PM 
```

Basically the issue we've been facing is around the fact that RAF is preventing component rendering in sync: i.e. we need to run function after a component has been loaded and nothing else can happen before hand". And removing this check allows for ordered events.

Thanks ^___^