### PR TITLE
Match proxy node name with element

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ Nanocomponent.prototype._handleRender = function (args) {
 }
 
 Nanocomponent.prototype._createProxy = function () {
-  var proxy = document.createElement('div')
+  var proxy = document.createElement(this._rootNodeName)
   var self = this
   this._brandNode(proxy)
   proxy.id = this._id

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -31,6 +31,7 @@ test('can create a simple component', function (t) {
   var proxy = comp.render('red')
   t.ok(proxy.dataset.proxy != null, 'proxy is returned on mounted component')
   t.equal(proxy.dataset.nanocomponent, comp._ncID, 'proxy is tagged with the correct ncID')
+  t.equal(proxy.nodeName, comp.element.nodeName, 'proxy is of same type')
   t.ok(proxy.isSameNode(comp.element), 'isSameNode works')
   t.ok(comp.element, 'component is still mounted in page')
   t.equal(comp.element.querySelector('.color').innerText, 'red', 'arguments correctly rendered')


### PR DESCRIPTION
As per discussion on irc, this would make sure that the proxy element is of the same node type that the rendered element. This would make it possible to morph a component onto itself, something that nanomorph won't allow if root node names differ. The motivation for this change is an experimental implementation of top level components in choo (see: https://github.com/yoshuawuyts/choo-component-preview)

```javascript
var element = component.render()
morph(element, component.render())
```