### PR TITLE
update all deps

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
-var document = require('global/document')
-var nanotiming = require('nanotiming')
-var morph = require('nanomorph')
-var onload = require('on-load')
-var OL_KEY_ID = onload.KEY_ID
-var OL_ATTR_ID = onload.KEY_ATTR
-var assert = require('assert')
+const document = require('global/document')
+const nanotiming = require('nanotiming')
+const morph = require('nanomorph')
+const onload = require('on-load')
+const assert = require('assert')
+
+const OL_KEY_ID = onload.KEY_ID
+const OL_ATTR_ID = onload.KEY_ATTR
 
 module.exports = Nanocomponent
 
@@ -28,37 +29,38 @@ function Nanocomponent (name) {
 
   this._arguments = []
 
-  var self = this
+  const self = this
 
   Object.defineProperty(this, 'element', {
     get: function () {
-      var el = document.getElementById(self._id)
+      const el = document.getElementById(self._id)
       if (el) return el.dataset.nanocomponent === self._ncID ? el : undefined
     }
   })
 }
 
 Nanocomponent.prototype.render = function () {
-  var renderTiming = nanotiming(this._name + '.render')
-  var self = this
-  var args = new Array(arguments.length)
-  var el
-  for (var i = 0; i < arguments.length; i++) args[i] = arguments[i]
+  const renderTiming = nanotiming(this._name + '.render')
+  const self = this
+  const args = new Array(arguments.length)
+  let el
+
+  for (let i = 0; i < arguments.length; i++) args[i] = arguments[i]
   if (!this._hasWindow) {
-    var createTiming = nanotiming(this._name + '.create')
+    const createTiming = nanotiming(this._name + '.create')
     el = this.createElement.apply(this, args)
     createTiming()
     renderTiming()
     return el
   } else if (this.element) {
     el = this.element // retain reference, as the ID might change on render
-    var updateTiming = nanotiming(this._name + '.update')
-    var shouldUpdate = this._rerender || this.update.apply(this, args)
+    const updateTiming = nanotiming(this._name + '.update')
+    const shouldUpdate = this._rerender || this.update.apply(this, args)
     updateTiming()
     if (this._rerender) this._rerender = false
     if (shouldUpdate) {
-      var desiredHtml = this._handleRender(args)
-      var morphTiming = nanotiming(this._name + '.morph')
+      const desiredHtml = this._handleRender(args)
+      const morphTiming = nanotiming(this._name + '.morph')
       morph(el, desiredHtml)
       morphTiming()
       if (this.afterupdate) this.afterupdate(el)
@@ -86,19 +88,19 @@ Nanocomponent.prototype.rerender = function () {
 }
 
 Nanocomponent.prototype._handleRender = function (args) {
-  var createElementTiming = nanotiming(this._name + '.createElement')
-  var el = this.createElement.apply(this, args)
+  const createElementTiming = nanotiming(this._name + '.createElement')
+  const el = this.createElement.apply(this, args)
   createElementTiming()
   if (!this._rootNodeName) this._rootNodeName = el.nodeName
   assert(el instanceof window.Element, 'nanocomponent: createElement should return a single DOM node')
-  assert.equal(this._rootNodeName, el.nodeName, 'nanocomponent: root node types cannot differ between re-renders')
+  assert(this._rootNodeName === el.nodeName, 'nanocomponent: root node types cannot differ between re-renders')
   this._arguments = args
   return this._brandNode(this._ensureID(el))
 }
 
 Nanocomponent.prototype._createProxy = function () {
-  var proxy = document.createElement(this._rootNodeName)
-  var self = this
+  const proxy = document.createElement(this._rootNodeName)
+  const self = this
   this._brandNode(proxy)
   proxy.id = this._id
   proxy.setAttribute('data-proxy', '')

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "run-s test:*",
-    "test:deps": "dependency-check .",
+    "test:deps": "dependency-check . --no-dev -i nanoassert",
     "test:node": "NODE_ENV=test node test/node.js | tap-format-spec",
     "test:browser": "browserify test/browser/index.js | tape-run --render='tap-format-spec'",
     "test:lint": "standard *.js",
@@ -42,28 +42,28 @@
   "homepage": "https://github.com/choojs/nanocomponent#readme",
   "dependencies": {
     "global": "^4.3.1",
-    "nanoassert": "^1.1.0",
+    "nanoassert": "^2.0.0",
     "nanomorph": "^5.1.2",
     "nanotiming": "^7.2.0",
-    "on-load": "^3.3.4"
+    "on-load": "^4.0.2"
   },
   "devDependencies": {
     "@tap-format/spec": "^0.2.0",
     "bankai": "^9.5.1",
     "browserify": "^16.0.0",
-    "choo": "^6.0.1",
+    "choo": "^7.1.0",
     "choo-log": "^8.0.0",
-    "dependency-check": "^3.0.0",
+    "dependency-check": "^4.1.0",
     "envify": "^4.0.0",
     "leaflet": "^1.1.0",
     "microbounce": "^1.0.0",
     "nanobus": "^4.2.0",
     "nanohtml": "^1.2.3",
-    "nanologger": "^1.3.1",
+    "nanologger": "^2.0.0",
     "npm-run-all": "^4.0.2",
     "on-idle": "^3.1.0",
-    "standard": "^11.0.1",
-    "tape": "^4.7.0",
-    "tape-run": "^4.0.0"
+    "standard": "^14.3.4",
+    "tape": "^5.0.0",
+    "tape-run": "^7.0.0"
   }
 }

--- a/test/browser/index.js
+++ b/test/browser/index.js
@@ -112,6 +112,7 @@ test('lifecycle tests', function (t) {
         unload: 0
       }
     }
+
     createElement (text) {
       this.arguments = arguments
       this.testState['create-element']++


### PR DESCRIPTION
- updated all outdated deps
- fixed syntax issues based on standard lint
- changed `assert.equal` to `assert` since nanoassert removed all methods (ref: https://github.com/emilbayes/nanoassert/commit/3f7c9ff2c88a064e3d5038e2b6e2d640e2f09698)

updating for the sake of forking to add some convenience since we're still using this heavily at work and we've run into a lot of boilerplate. will send some upstream patches if they make sense

👋 